### PR TITLE
Fix Julia 0.7 tests and deprecation warnings

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
-julia 0.5
+julia 0.6
+Compat 0.59

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,8 +19,11 @@
 
 ### Code:
 
+module PolynomialRootsTests
+
 using PolynomialRoots
-using Base.Test
+using Compat.Test
+import Compat: ComplexF64
 
 import PolynomialRoots: evalpoly
 
@@ -77,7 +80,7 @@ end
 @testset "0th-order polynomials" begin
     poly = [1]
     res  = @inferred(roots(poly))
-    @test Array{Complex128}(0) == res
+    @test ComplexF64[] == res
 end
 
 @testset "1st-order polynomials" begin
@@ -233,3 +236,5 @@ end
     @test_throws AssertionError @inferred(roots5([1,2,3]))
     @test_throws AssertionError @inferred(roots5([1,2,3,4,5,6], [1]))
 end
+
+end # module


### PR DESCRIPTION
Tests for 5-th order polynomials failed, after some investigation it seems like the implementation of `::Complex ^ ::Float` has changed since 0.6 and now has a bit less precision. Fixed by replacing the `a ^ b` operator with `exp(log(a) * b)` (this is basically how 0.6 implements exponentiation). I'm going to file a bug report against Julia when I get the time to do so.

I also fixed a deprecation warning regarding loop scope changes by introducing another auxiliary variable.