### PR TITLE
Truncate polynomial if it has zeros in the trailing elements

### DIFF
--- a/src/PolynomialRoots.jl
+++ b/src/PolynomialRoots.jl
@@ -609,8 +609,15 @@ end
 
 function roots(poly::AbstractVector{N}; epsilon::AbstractFloat=NaN,
                polish::Bool=false) where {N<:Number}
-    degree = length(poly) - 1
-    roots!(zeros(Complex{real(float(N))}, degree), float.(complex(poly)),
+    # Before starting, truncate the polynomial if it has zeros in the trailing elements
+    last_nz = findlast(!iszero, poly)
+    if lastindex(poly) == last_nz
+        _poly = poly
+    else
+        _poly = poly[1:last_nz]
+    end
+    degree = length(_poly) - 1
+    roots!(zeros(Complex{real(float(N))}, degree), float.(complex(_poly)),
            epsilon, degree, polish)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -228,6 +228,9 @@ end
             -47.40236121905153, -71.92379520244637, -57.977452001749555]
     @test isapprox(zeros(length(poly)-1),
                    evalpoly(@inferred(roots(poly)), poly), atol = 2e-11)
+    # https://github.com/giordano/PolynomialRoots.jl/issues/11
+    poly = [1.0, -2.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    @test isapprox(@inferred(roots(poly)), [1, 1])
 end
 
 @testset "Errors" begin


### PR DESCRIPTION
Before the PR:
```julia
julia> roots([1, -2, 1, 0, 0, 0])
5-element Array{Complex{Float64},1}:
               -0.0 - 0.0im               
               -0.0 - 0.0im               
 -6120.142457360636 + 1922.2699239774856im
  1.000000005275489 + 0.0im               
 0.9999999947245112 + 0.0im
```
After the PR:
```julia
julia> roots([1, -2, 1, 0, 0, 0])
2-element Array{Complex{Float64},1}:
 1.0 - 0.0im
 1.0 + 0.0im

julia> roots([0, 1, 4, 1, 0, 0, 0])
3-element Array{Complex{Float64},1}:
  -3.732050807568877 + 0.0im
 -0.2679491924311227 - 0.0im
                 0.0 + 0.0im
```

Fix #11 CC: @yhkalayci