### PR TITLE
Handle all-zeros polynomial

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PolynomialRoots"
 uuid = "3a141323-8675-5d76-9d11-e1df1406c778"
 authors = ["Mosè Giordano <mose@gnu.org>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [compat]
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Mosè Giordano <mose@gnu.org>"]
 version = "1.0.1"
 
 [compat]
-julia = "1"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PolynomialRoots"
 uuid = "3a141323-8675-5d76-9d11-e1df1406c778"
 authors = ["Mosè Giordano <mose@gnu.org>"]
-version = "1.0.1"
+version = "1.1.0"
 
 [compat]
 julia = "1.10"

--- a/src/PolynomialRoots.jl
+++ b/src/PolynomialRoots.jl
@@ -611,6 +611,7 @@ function roots(poly::AbstractVector{N}; epsilon::AbstractFloat=NaN,
                polish::Bool=false) where {N<:Number}
     # Before starting, truncate the polynomial if it has zeros in the trailing elements
     last_nz = findlast(!iszero, poly)
+    last_nz === nothing && return Complex{real(float(N))}[NaN]
     if lastindex(poly) == last_nz
         _poly = poly
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,6 +80,9 @@ end
     poly = [1]
     res  = @inferred(roots(poly))
     @test ComplexF64[] == res
+
+    res = @inferred(roots([0]))
+    @test isnan(only(res))
 end
 
 @testset "1st-order polynomials" begin
@@ -161,7 +164,7 @@ end
     @test isapprox(zeros(length(poly) - 1),
                    evalpoly(@inferred(roots(poly)), poly), atol = 3e-14)
     @test isapprox(zeros(length(poly) - 1),
-                   evalpoly(@inferred(roots5(poly, ones(5))), poly), atol = 3e-14)
+                   evalpoly(@inferred(roots5(poly, ones(5))), poly), atol = 1e-13)
     poly = [(8.2 + 1.79im), -(8.38 + 1.57im), -(7.33 - 3.94im), (4.91 - 4.37im), (5.52 + 5.68im), -(3.9 - 7.12im)]
     @test isapprox(zeros(length(poly) - 1),
                    evalpoly(@inferred(roots(poly)), poly), atol = 3e-14)
@@ -180,7 +183,7 @@ end
     @test isapprox(zeros(length(poly) - 1),
                    evalpoly(@inferred(roots(poly)), poly), atol = 6e-14)
     @test isapprox(zeros(length(poly) - 1),
-                   evalpoly(@inferred(roots5(poly, ones(5))), poly), atol = 2e-14)
+                   evalpoly(@inferred(roots5(poly, ones(5))), poly), atol = 1e-13)
     tol  = 2e-12
     poly = [120im, -(184 + 90im), (138 - 57im), (54im - 15), -(6 + 9im), 1]
     res  = @inferred(roots(poly,  [im, 2, 3im, 4, 5im]))


### PR DESCRIPTION
Passing a coefficients array filled with zeros to `roots` resulted in an indexing bug. It's not entirely clear what should be returned in this case, so I chose `NaN`. Ideally one might return `-Inf .. Inf`, but it seems a little silly to depend on IntervalSets for this one case.

Detected by JET.
Fixes #28

~I should add that this also tweaks two tolerances in the tests which were needed for passing on my machine.~ (Update: merged in #31)